### PR TITLE
Add route_hint support to keysend

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -128,7 +128,7 @@ export default class Sphinx implements SphinxProvider {
     return null;
   }
 
-  async keysend(dest: string, amt: number) {
+  async keysend(dest: string, amt: number, routeHint?: string) {
     if (this.logging) console.log("=> KEYSEND");
     if (!this.isEnabled) return null;
     if (!dest || !amt) return null;
@@ -137,6 +137,7 @@ export default class Sphinx implements SphinxProvider {
     if (amt > this.budget) return null;
     try {
       const args: KeysendArgs = { dest, amt };
+      if (routeHint) args.route_hint = routeHint;
       const r = await this.postMsg<KeysendRes, KeysendArgs>(
         MSG_TYPE.KEYSEND,
         args

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -14,6 +14,7 @@ export interface EnableRes {
 export interface KeysendArgs {
   amt: number;
   dest: string;
+  route_hint?: string;
 }
 export interface KeysendRes {
   success: boolean;
@@ -116,7 +117,7 @@ export interface SphinxProvider {
 
   authorize(challenge: string): Promise<AuthorizeRes | null>;
 
-  keysend(dest: string, amt: number): Promise<KeysendRes | null>;
+  keysend(dest: string, amt: number, routeHint?: string): Promise<KeysendRes | null>;
 
   updated(): Promise<undefined | null>;
 


### PR DESCRIPTION
Keysend to nodes behind an LSP requires a route hint. Pass it through KeysendArgs so the native app can route the payment.